### PR TITLE
Hero 콜라이더 변경 Feature/munbin/#24

### DIFF
--- a/Unity/Assets/BT/Reset.cs
+++ b/Unity/Assets/BT/Reset.cs
@@ -1,4 +1,3 @@
-using System;
 using MBT;
 using UnityEngine;
 
@@ -6,20 +5,10 @@ namespace BT
 {
     [AddComponentMenu("")]
     [MBTNode(name = "Hero/Reset")]
-    public class Reset: Leaf
+    public class Reset : Leaf
     {
-        private BoxCollider2D _boxCollider2D;
-
-        private void Start()
-        {
-            _boxCollider2D = GetComponent<BoxCollider2D>();
-        }
-
         public override NodeResult Execute()
         {
-            _boxCollider2D.size = new Vector2(_boxCollider2D.size.x, 1.3f);
-            _boxCollider2D.offset = new Vector2(_boxCollider2D.offset.x, 0.7f);
-            
             return NodeResult.success;
         }
     }

--- a/Unity/Assets/BT/Roll.cs
+++ b/Unity/Assets/BT/Roll.cs
@@ -1,4 +1,3 @@
-using System;
 using MBT;
 using UnityEngine;
 
@@ -12,8 +11,7 @@ namespace BT
         private Animator _animator;
         private SpriteRenderer _spriteRenderer;
         private Rigidbody2D _rigidbody2D;
-        private BoxCollider2D _boxCollider2D;
-        
+
         public Vector2 originalSize;
         public Vector2 originalOffset;
 
@@ -22,30 +20,22 @@ namespace BT
             _animator = GetComponent<Animator>();
             _spriteRenderer = GetComponent<SpriteRenderer>();
             _rigidbody2D = GetComponent<Rigidbody2D>();
-            _boxCollider2D = GetComponent<BoxCollider2D>();
-            
-            originalSize = _boxCollider2D.size;
-            originalOffset = _boxCollider2D.offset;
-            
         }
 
         public override NodeResult Execute()
         {
-            var inputX = Input.GetAxis("Horizontal");
-                switch (_spriteRenderer.flipX)
-                {
-                    case true:
-                        _rigidbody2D.velocity = new Vector2(-moveSpeed, _rigidbody2D.velocity.y);
-                        break;
-                    case false:
-                        _rigidbody2D.velocity = new Vector2(moveSpeed, _rigidbody2D.velocity.y);
-                        break;
-                }
-            
+            switch (_spriteRenderer.flipX)
+            {
+                case true:
+                    _rigidbody2D.velocity = new Vector2(-moveSpeed, _rigidbody2D.velocity.y);
+                    break;
+                case false:
+                    _rigidbody2D.velocity = new Vector2(moveSpeed, _rigidbody2D.velocity.y);
+                    break;
+            }
+
             _animator.Play("Roll");
-            _boxCollider2D.size = new Vector2(_boxCollider2D.size.x, 0.6f);
-            _boxCollider2D.offset = new Vector2(_boxCollider2D.offset.x, 0.4f);
-            
+
             return NodeResult.success;
         }
     }

--- a/Unity/Assets/Hero/Hero.prefab
+++ b/Unity/Assets/Hero/Hero.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 7813450559281782495}
   - component: {fileID: 6446472560114449932}
   - component: {fileID: 7784088157742165513}
-  - component: {fileID: 7805368292479922755}
   - component: {fileID: 2816102555081676567}
   - component: {fileID: 284227325345068008}
   - component: {fileID: 1964001512611232424}
@@ -52,6 +51,7 @@ GameObject:
   - component: {fileID: 5568301039347657639}
   - component: {fileID: 2108809515485989908}
   - component: {fileID: 3178624497427637332}
+  - component: {fileID: 5966586726503547564}
   m_Layer: 0
   m_Name: Hero
   m_TagString: Player
@@ -153,51 +153,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!61 &7805368292479922755
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5548069816130054504}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.7}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0}
-    oldSize: {x: 3.125, y: 1.71875}
-    newSize: {x: 3.125, y: 1.71875}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.7, y: 1.3}
-  m_EdgeRadius: 0
 --- !u!114 &2816102555081676567
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1213,3 +1168,38 @@ MonoBehaviour:
   runtimePriority: 0
   breakpoint: 0
   moveSpeed: 5
+--- !u!70 &5966586726503547564
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5548069816130054504}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.7}
+  m_Size: {x: 0.7, y: 1.3}
+  m_Direction: 0


### PR DESCRIPTION
Hero 콜라이더를 CapsuleCollider2D로 변경하였고,

기존의 BoxCollider2D를 참조하는 Roll 노드와 Reset 노드의 콜라이더 변경 기능을 삭제하였습니다.